### PR TITLE
Add colorizing for multi-line strings

### DIFF
--- a/src/Editor/EditorFeatures.cs
+++ b/src/Editor/EditorFeatures.cs
@@ -28,6 +28,7 @@ namespace TomlEditor
             { TokenKind.Integer, PredefinedClassificationTypeNames.Number },
             { TokenKind.True, PredefinedClassificationTypeNames.Keyword },
             { TokenKind.False, PredefinedClassificationTypeNames.Keyword },
+            { TokenKind.StringMulti, PredefinedClassificationTypeNames.String },
         };
     }
 


### PR DESCRIPTION
[Screenshot](https://imgur.com/PPRtzKm)

Adds support for triple-quote multi-line strings in the text editor. Currently, there is no syntax highlighting, and it remains all in white.